### PR TITLE
Issue/Export-with-buttits-instead-of-dashes

### DIFF
--- a/src/GrindTreeviewProvider.ts
+++ b/src/GrindTreeviewProvider.ts
@@ -5,7 +5,13 @@ import { Logger } from "./services/Logger";
 import { Storage } from "./services/Storage";
 import { Day } from "./classes/entities/Day";
 import { Task } from "./classes/entities/Task";
-import { ENABLE_COMPLETIONS, STORAGE_SCOPE } from "./consts";
+import {
+  ENABLE_COMPLETIONS,
+  EXPORT_FORMAT,
+  SPACES_IN_INDENT,
+  STORAGE_SCOPE,
+} from "./consts";
+import { BULLETS } from "./helpers/characters";
 
 export class GrindTreeviewProvider
   implements vscode.TreeDataProvider<vscode.TreeItem>
@@ -124,12 +130,23 @@ export class GrindTreeviewProvider
       for (const task of tasks) {
         const t = this.storage.get<Task>(task);
         if (t) {
-          result = result.concat(
-            `${" ".repeat(indent)}- ${
-              ENABLE_COMPLETIONS ? `[${t.completed ? "x" : " "}]` : ""
-            } ${t.label}\n`
-          );
-          result = result + appendTasks(t.subtasks, indent + 2);
+          switch (EXPORT_FORMAT) {
+            case "markdown":
+              result = result.concat(
+                `${" ".repeat(indent * SPACES_IN_INDENT)}- ${
+                  ENABLE_COMPLETIONS ? `[${t.completed ? "x" : " "}]` : ""
+                } ${t.label}\n`
+              );
+            case "richtext":
+              result = result.concat(
+                `${" ".repeat(indent * SPACES_IN_INDENT)}${
+                  BULLETS[indent % 3]
+                } ${ENABLE_COMPLETIONS ? `[${t.completed ? "x" : " "}]` : ""} ${
+                  t.label
+                }\n`
+              );
+          }
+          result = result + appendTasks(t.subtasks, indent + 1);
         }
       }
 

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -1,4 +1,5 @@
 export const ENABLE_COMPLETIONS = false;
 export const EXPORT_FORMAT: "richtext" | "markdown" = "richtext";
+export const SPACES_IN_INDENT: number = 2;
 
 export const STORAGE_SCOPE: "global" | "workspace" = "workspace"; // Allow this to be set to workplace storage via settings

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -1,3 +1,4 @@
 export const ENABLE_COMPLETIONS = false;
+export const EXPORT_FORMAT: "richtext" | "markdown" = "richtext";
 
 export const STORAGE_SCOPE: "global" | "workspace" = "workspace"; // Allow this to be set to workplace storage via settings

--- a/src/helpers/characters.ts
+++ b/src/helpers/characters.ts
@@ -1,0 +1,7 @@
+export const BULLETS = ["\u2022", "\u29BF", "\u2023"];
+
+// •  Task
+// •  More task
+//   ⦿  Subtask
+//     ‣  subsub
+//       •  subsubsub


### PR DESCRIPTION
- introduce EXPORT_FORMAT for different output styles (markdown, richtext)
- add BULLETS for richtext export to enhance visual differentiation

🔧 chore(consts): define spaces in indent as a constant

- add SPACES_IN_INDENT to control indentation size dynamically

🌐 i18n(helpers): configure bullet characters for various indentations

- create BULLETS array to store different bullet characters for multiple levels of indentation