### PR TITLE
🐛 fix(treeview): update storage on task edit

### DIFF
--- a/src/GrindTreeviewProvider.ts
+++ b/src/GrindTreeviewProvider.ts
@@ -118,7 +118,8 @@ export class GrindTreeviewProvider
   }
 
   async edit(element: TaskTreeItem, update: string): Promise<void> {
-    // Edit given todo
+    const task = this.storage.get<Task>(element.task.id);
+    this.storage.set(task.id, { ...task, label: update });
 
     this.refresh();
   }


### PR DESCRIPTION
- retrieve task from storage before editing
- update task label in storage correctly