### PR TITLE
Issue/Add-task-to-tomorrow

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,11 @@
         "category": "Grind"
       },
       {
+        "command": "grind.add-to-tomorrow",
+        "title": "Add to Tomorrow",
+        "category": "Grind"
+      },
+      {
         "command": "grind.add-to-day",
         "title": "Add to Day",
         "category": "Grind"

--- a/src/classes/entities/Day.ts
+++ b/src/classes/entities/Day.ts
@@ -124,7 +124,8 @@ export class Day {
             .startOf("day")
             .add(d + 1, "day")
         )
-      );
+      )
+      .reverse();
   }
 
   /**

--- a/src/classes/entities/Day.ts
+++ b/src/classes/entities/Day.ts
@@ -105,6 +105,29 @@ export class Day {
   }
 
   /**
+   * Returns an array of formatted date strings representing the specified number of days ahead from today.
+   *
+   * This method generates a list where each entry corresponds to a future day, starting from
+   * today and going forward the given number of days. For example, calling `daysAhead(3)`
+   * would return an array containing today's date and the two subsequent days in the format
+   * "YYYY-MM-DD".
+   *
+   * @param days - The number of days to go forward from today.
+   * @returns An array of formatted date strings for each day going forward from today.
+   */
+  static daysAhead(days: number): string[] {
+    return Array(days)
+      .fill(0)
+      .map((_, d): string =>
+        Day.toKey(
+          dayjs()
+            .startOf("day")
+            .add(d + 1, "day")
+        )
+      );
+  }
+
+  /**
    * Formats a Day.js object into a string representation of the date.
    *
    * This method converts a Day.js instance into a formatted date string in the

--- a/src/classes/entities/Day.ts
+++ b/src/classes/entities/Day.ts
@@ -114,7 +114,10 @@ export class Day {
    * @param day - A Day.js object representing the date to format.
    * @returns A string formatted as "YYYY-MM-DD" representing the given date.
    */
-  static toKey(day: dayjs.Dayjs) {
+  static toKey(day: dayjs.Dayjs | string) {
+    if (typeof day === "string") {
+      day = dayjs(day);
+    }
     return day.format("YYYY-MM-DD");
   }
 

--- a/src/classes/entities/Day.ts
+++ b/src/classes/entities/Day.ts
@@ -82,6 +82,20 @@ export class Day {
   }
 
   /**
+   * Returns a formatted date string representing the specified number of days ahead from today.
+   *
+   * This method calculates the date that is the given number of days in the future from today
+   * and returns it in the format "YYYY-MM-DD". For example, calling `dayAhead(3)` would return
+   * the date string corresponding to three days after today.
+   *
+   * @param days - The number of days to go forward from today.
+   * @returns A formatted date string representing the date from the specified number of days ahead.
+   */
+  static dayAhead(days: number): string {
+    return Day.toKey(dayjs().startOf("day").add(days, "day"));
+  }
+
+  /**
    * Returns an array of formatted date strings representing the specified number of days ago.
    *
    * This method generates a list where each entry corresponds to a day, starting from

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -90,6 +90,12 @@ export function activate(context: vscode.ExtensionContext) {
     await addToSubtask(date, tasks);
   });
 
+  vscode.commands.registerCommand("grind.add-to-tomorrow", async () => {
+    const { date, tasks } = storage.get<Day>(Day.dayAhead(1));
+
+    await addToSubtask(date, tasks);
+  });
+
   vscode.commands.registerCommand("grind.add-to-day", async () => {
     const chosenDay = await UserInput.promptDateSelection();
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -91,9 +91,11 @@ export function activate(context: vscode.ExtensionContext) {
   });
 
   vscode.commands.registerCommand("grind.add-to-tomorrow", async () => {
-    const { date, tasks } = storage.get<Day>(Day.dayAhead(1));
+    const day = await storage.getOrCreateDay(Day.dayAhead(1));
 
-    await addToSubtask(date, tasks);
+    if (!!day) {
+      await addToSubtask(day.date, day.tasks);
+    }
   });
 
   vscode.commands.registerCommand("grind.add-to-day", async () => {

--- a/src/services/Storage.ts
+++ b/src/services/Storage.ts
@@ -44,6 +44,19 @@ export class Storage {
     return this.storage.get<T>(key, null as T);
   }
 
+  public async getOrCreateDay(key: string): Promise<Day | null> {
+    const value = this.storage.get<Day | null>(key, null);
+    if (!value) {
+      if (Day.validate(key)) {
+        const day = new Day(key);
+        await this.storage.update(key, day);
+        return day as Day;
+      }
+      return this.storage.get<Day | null>(key, null);
+    }
+    return value;
+  }
+
   /**
    * Stores a value associated with the specified key in the storage.
    * This method is asynchronous, allowing for non-blocking storage of data.

--- a/src/services/UserInput.ts
+++ b/src/services/UserInput.ts
@@ -31,7 +31,11 @@ export class UserInput {
   public static async promptDateSelection(
     daysAgo: number = 10
   ): Promise<string> {
-    const options = Day.daysAgo(daysAgo).reduce((acc, d) => {
+    const options = [
+      ...Day.daysAhead(daysAgo),
+      Day.today,
+      ...Day.daysAgo(daysAgo),
+    ].reduce((acc, d) => {
       acc[Day.format(d)] = d;
       return acc;
     }, {} as Record<string, string>);

--- a/src/services/UserInput.ts
+++ b/src/services/UserInput.ts
@@ -1,5 +1,6 @@
 import * as vscode from "vscode";
 import { Day } from "../classes/entities/Day";
+import dayjs = require("dayjs");
 
 export class UserInput {
   public static async promptNewTask(): Promise<string> {
@@ -27,17 +28,22 @@ export class UserInput {
     return task;
   }
 
-  public static async promptDateSelection(daysAgo: number = 10) {
-    const options = Day.daysAgo(daysAgo);
+  public static async promptDateSelection(
+    daysAgo: number = 10
+  ): Promise<string> {
+    const options = Day.daysAgo(daysAgo).reduce((acc, d) => {
+      acc[Day.format(d)] = d;
+      return acc;
+    }, {} as Record<string, string>);
 
-    const day = await vscode.window.showQuickPick(options, {
+    const day = await vscode.window.showQuickPick(Object.keys(options), {
       placeHolder: "Select a day",
     });
 
     if (!day) {
       throw new Error("No day selected");
+    } else {
+      return options[day];
     }
-
-    return day;
   }
 }


### PR DESCRIPTION
- add getOrCreateDay method for retrieving or creating a day entry
- update command to use getOrCreateDay for better data handling

🐛 fix(extension): handle null day scenario

- check for null day object before adding subtasks
- ensure robustness with day retrieval and task addition