### PR TITLE
Issue/Activate-on-commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,8 +22,7 @@
   "main": "./out/extension.js",
   "contributes": {
     "activationEvents": [
-      "onCommand:grind.refresh",
-      "onCommand:grind.reset",
+      "onCommand:*",
       "onView:grind-explorer",
       "onView:grind-sidebar"
     ],

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -85,7 +85,7 @@ export function activate(context: vscode.ExtensionContext) {
   };
 
   vscode.commands.registerCommand("grind.add-to-today", async () => {
-    const { date, tasks } = storage.get<Day>(Day.today);
+    const { date, tasks } = storage.get<Day>(Day.today, new Day(Day.today));
 
     await addToSubtask(date, tasks);
   });

--- a/src/services/Storage.ts
+++ b/src/services/Storage.ts
@@ -40,8 +40,8 @@ export class Storage {
    * @param {string} key - The key associated with the value to retrieve.
    * @returns {T} - The value associated with the key, or null if the key does not exist.
    */
-  public get<T>(key: string): T {
-    return this.storage.get<T>(key, null as T);
+  public get<T>(key: string, defaultValue?: T): T {
+    return this.storage.get<T>(key, defaultValue ?? (null as T));
   }
 
   public async getOrCreateDay(key: string): Promise<Day | null> {


### PR DESCRIPTION
- add default Day instance in storage.get call to prevent undefined errors

🐛 fix(storage): add default value parameter in get method

- modify get method to accept a default value for better flexibility and error prevention